### PR TITLE
Bump ArgoCD helm chart to 6.5.0 (Argo CD version 2.10.1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "helm_release" "argocd" {
   namespace        = try(var.argocd.namespace, "argocd")
   create_namespace = try(var.argocd.create_namespace, true)
   chart            = try(var.argocd.chart, "argo-cd")
-  version          = try(var.argocd.chart_version, "5.51.6")
+  version          = try(var.argocd.chart_version, "6.5.0")
   repository       = try(var.argocd.repository, "https://argoproj.github.io/argo-helm")
   values           = try(var.argocd.values, [])
 


### PR DESCRIPTION
Changes the default version of the ArgoCD Helm Chart to 6.5.0

It will install Argo CD 2.10.1